### PR TITLE
chore(package) update build-kong command to copy styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "automated-release": "release-it -VV --config ./release/.release-it.json",
     "build": "run-p --aggregate-output build-core build-bundle build-standalone build-stylesheets",
-    "build-kong": "npm run build && cp dist/swagger-ui-bundle.js ../kong-portal-templates/workspaces/default/themes/base/assets/js/third-party/swagger-ui-bundle.kong.$(git rev-parse --short HEAD).js",
+    "build-kong": "npm run build && cp dist/swagger-ui-bundle.js ../kong-portal-templates/workspaces/default/themes/base/assets/js/third-party/swagger-ui-bundle.kong.$(git rev-parse --short HEAD).js && cp dist/swagger-ui.css ../kong-portal-templates/workspaces/default/themes/base/assets/styles/swagger-ui.kong.$(git rev-parse --short HEAD).css",
     "build-bundle": "webpack --colors --config webpack/bundle.babel.js",
     "build-core": "webpack --colors --config webpack/core.babel.js",
     "build-standalone": "webpack --colors --config webpack/standalone.babel.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This adds a `cp` step for `dist/swagger-ui.css` to be copied into a sibling `kong-portal-templates` repo in the desired assets location

