### PR TITLE
fix(a11y) heading levels and labels [TDX-1647]

### DIFF
--- a/src/core/components/errors.jsx
+++ b/src/core/components/errors.jsx
@@ -36,25 +36,27 @@ export default class Errors extends React.Component {
     let sortedJSErrors = allErrorsToDisplay.sortBy(err => err.get("line"))
 
     return (
-      <pre className="errors-wrapper">
-        <hgroup className="error">
-          <h4 className="errors__title">Errors</h4>
-          <button className="btn errors__clear-btn" onClick={ toggleVisibility }>{ isVisible ? "Hide" : "Show" }</button>
-        </hgroup>
-        <Collapse isOpened={ isVisible } animated >
-          <div className="errors">
-            { sortedJSErrors.map((err, i) => {
-              let type = err.get("type")
-              if(type === "thrown" || type === "auth") {
-                return <ThrownErrorItem key={ i } error={ err.get("error") || err } jumpToLine={jumpToLine} />
-              }
-              if(type === "spec") {
-                return <SpecErrorItem key={ i } error={ err } jumpToLine={jumpToLine} />
-              }
-            }) }
-          </div>
-        </Collapse>
-      </pre>
+      <section>
+        <pre className="errors-wrapper">
+          <hgroup className="error">
+            <h1 className="errors__title">Errors</h1>
+            <button className="btn errors__clear-btn" onClick={ toggleVisibility }>{ isVisible ? "Hide" : "Show" }</button>
+          </hgroup>
+          <Collapse isOpened={ isVisible } animated >
+            <div className="errors">
+              { sortedJSErrors.map((err, i) => {
+                let type = err.get("type")
+                if(type === "thrown" || type === "auth") {
+                  return <ThrownErrorItem key={ i } error={ err.get("error") || err } jumpToLine={jumpToLine} />
+                }
+                if(type === "spec") {
+                  return <SpecErrorItem key={ i } error={ err } jumpToLine={jumpToLine} />
+                }
+              }) }
+            </div>
+          </Collapse>
+        </pre>
+      </section>
       )
     }
 }
@@ -69,9 +71,9 @@ const ThrownErrorItem = ( { error, jumpToLine } ) => {
     <div className="error-wrapper">
       { !error ? null :
         <div>
-          <h4>{ (error.get("source") && error.get("level")) ?
+          <p className="error-source">{ (error.get("source") && error.get("level")) ?
             toTitleCase(error.get("source")) + " " + error.get("level") : "" }
-          { error.get("path") ? <small> at {error.get("path")}</small>: null }</h4>
+          { error.get("path") ? <small> at {error.get("path")}</small>: null }</p>
           <span style={{ whiteSpace: "pre-line", "maxWidth": "100%" }}>
             { error.get("message") }
           </span>
@@ -101,7 +103,7 @@ const SpecErrorItem = ( { error, jumpToLine } ) => {
     <div className="error-wrapper">
       { !error ? null :
         <div>
-          <h4>{ toTitleCase(error.get("source")) + " " + error.get("level") }&nbsp;{ locationMessage }</h4>
+          <p className="error-source">{ toTitleCase(error.get("source")) + " " + error.get("level") }&nbsp;{ locationMessage }</p>
           <span style={{ whiteSpace: "pre-line"}}>{ error.get("message") }</span>
           <div style={{ "text-decoration": "underline", "cursor": "pointer" }}>
             { jumpToLine ? (

--- a/src/core/components/highlight-code.jsx
+++ b/src/core/components/highlight-code.jsx
@@ -53,7 +53,7 @@ export default class HighlightCode extends Component {
     return (
       <div className="highlight-code">
         { !downloadable ? null :
-          <div className="download-contents" onClick={this.downloadText}>
+          <div className="download-contents" onClick={this.downloadText} role="button" aria-label="download contents">
             Download
           </div>
         }

--- a/src/core/components/parameters/parameters.jsx
+++ b/src/core/components/parameters/parameters.jsx
@@ -180,7 +180,7 @@ export default class Parameters extends Component {
           isOAS3 && requestBody && this.state.parametersVisible &&
           <div className="opblock-section opblock-section-request-body">
             <div className="opblock-section-header">
-              <h4 className={`opblock-title parameter__name ${requestBody.get("required") && "required"}`}>Request body</h4>
+              <h1 className={`opblock-title parameter__name ${requestBody.get("required") && "required"}`}>Request body</h1>
               <label>
                 <ContentType
                   value={oas3Selectors.requestContentType(...pathMethod)}

--- a/src/core/json-schema-components.jsx
+++ b/src/core/json-schema-components.jsx
@@ -108,6 +108,7 @@ export class JsonSchema_string extends Component {
           type={format && format === "password" ? "password" : "text"}
           className={errors.length ? "invalid" : ""}
           title={errors.length ? errors : ""}
+          aria-label={description}
           value={value}
           minLength={0}
           debounceTimeout={350}

--- a/src/core/plugins/oas3/components/callbacks.jsx
+++ b/src/core/plugins/oas3/components/callbacks.jsx
@@ -13,8 +13,8 @@ const Callbacks = (props) => {
   }
 
   let callbackElements = callbacks.map((callback, callbackName) => {
-    return <div key={callbackName}>
-      <h2>{callbackName}</h2>
+    return <section key={callbackName}>
+      <h1>{callbackName}</h1>
       { callback.map((pathItem, pathItemName) => {
         if(pathItemName === "$$ref") {
           return null
@@ -40,7 +40,7 @@ const Callbacks = (props) => {
           }) }
         </div>
       }) }
-    </div>
+    </section>
   })
   return <div>
     {callbackElements}

--- a/src/style/_errors.scss
+++ b/src/style/_errors.scss
@@ -16,7 +16,7 @@
 
     .errors
     {
-        h4
+        p.error-source
         {
             font-size: 14px;
 
@@ -37,7 +37,7 @@
 
         align-items: center;
 
-        h4
+        h1
         {
             font-size: 20px;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This resolves:
- form elements should have visible label [TDX-1648]
- callback tab a11y [TDX-1647]
- download button a11y [TDX-1650]
- heading level must only increase by one [TDX-1649]

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.


[TDX-1648]: https://konghq.atlassian.net/browse/TDX-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TDX-1647]: https://konghq.atlassian.net/browse/TDX-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TDX-1650]: https://konghq.atlassian.net/browse/TDX-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TDX-1649]: https://konghq.atlassian.net/browse/TDX-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ