### PR TITLE
fix(a11y) text area and array input label 

### DIFF
--- a/src/core/json-schema-components.jsx
+++ b/src/core/json-schema-components.jsx
@@ -220,12 +220,14 @@ export class JsonSchema_array extends PureComponent {
                     onChange={(val)=> this.onItemChange(val, i)}
                     disabled={disabled}
                     errors={errors}
+                    description={`${description} #${i}`}
                     getComponent={getComponent}
                     />
                     : isArrayItemText ?
                       <JsonSchemaArrayItemText
                         value={item}
                         onChange={(val) => this.onItemChange(val, i)}
+                        description={`${description} #${i}`}
                         disabled={disabled}
                         errors={errors}
                       />
@@ -286,6 +288,7 @@ export class JsonSchemaArrayItemText extends Component {
       value={value}
       minLength={0}
       debounceTimeout={350}
+      aria-label={description}
       placeholder={description}
       onChange={this.onChange}
       disabled={disabled} />)
@@ -302,13 +305,14 @@ export class JsonSchemaArrayItemFile extends Component {
   }
 
   render() {
-    let { getComponent, errors, disabled } = this.props
+    let { getComponent, errors, disabled, description } = this.props
     const Input = getComponent("Input")
     const isDisabled = disabled || !("FormData" in window)
 
     return (<Input type="file"
       className={errors.length ? "invalid" : ""}
       title={errors.length ? errors : ""}
+      aria-label={description}
       onChange={this.onFileChange}
       disabled={isDisabled} />)
   }

--- a/src/core/plugins/oas3/components/request-body-editor.jsx
+++ b/src/core/plugins/oas3/components/request-body-editor.jsx
@@ -10,6 +10,7 @@ export default class RequestBodyEditor extends PureComponent {
     onChange: PropTypes.func,
     getComponent: PropTypes.func.isRequired,
     value: PropTypes.string,
+    description: PropTypes.description,
     defaultValue: PropTypes.string,
   };
 
@@ -74,7 +75,8 @@ export default class RequestBodyEditor extends PureComponent {
 
   render() {
     let {
-      getComponent
+      getComponent,
+      description
     } = this.props
 
     let {
@@ -88,6 +90,7 @@ export default class RequestBodyEditor extends PureComponent {
         <TextArea
           className={"body-param__text"}
           value={value}
+          description={`Body param for ${description}`}
           onChange={ this.onDomChange }
         />
       </div>

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -208,6 +208,7 @@ const RequestBody = ({
       isExecute ? (
         <div>
           <RequestBodyEditor
+            description={requestBodyDescription}
             value={requestBodyValue}
             defaultValue={getDefaultRequestBodyValue(
               requestBody,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This adds `aria-label` attributes for body param text area elements and body param array elements.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improves accessibility of the inputs to meet WCAG AA standards
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
Axe browser extension
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
