### PR TITLE
chore(ci) a step cannot have both the `uses` and `run` keys

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,10 +26,6 @@ jobs:
           path: dist/*
           if-no-files-found: error
       - name: Commit files
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
-          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
         run: |
           date > generated.txt
           git config user.name github-actions


### PR DESCRIPTION
since the job already - uses: actions/checkout@v2
we can just do the new - run section you added and leave it at that without name, uses, and with properties